### PR TITLE
Don't autofind if the file doesn't exist within current path

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -416,7 +416,7 @@ endfun
 " s:NERDTreeFindFile() {{{
 "
 fun! s:NERDTreeFindFile()
-  if s:IsNERDTreeOpenInCurrentTab() && bufname('%') != ''
+  if s:IsNERDTreeOpenInCurrentTab() && bufname('%') != '' && expand('%:p:h') =~ getcwd()
     silent NERDTreeFind
   endif
 endfun


### PR DESCRIPTION
`vim-fugitive` command `Gblame` leads vim to open a temporary file, which changes current root path when `g:nerdtree_tabs_autofind = 1`